### PR TITLE
Fix undefined variable usage in crawler

### DIFF
--- a/src/crawler/code.py
+++ b/src/crawler/code.py
@@ -102,12 +102,11 @@ def run(url):
     except Exception as e:
         print('error')
         print(e)
-        print(i)
-        print(total)
+        print(f"mid: {mid} total: {total}")
         return
     with lock:
         result.append(users)  # 加锁保证多线程写入安全
-        print(i)
+        print(f"processed mid {mid}")
         print(total)
         total += 1
 


### PR DESCRIPTION
## Summary
- fix NameError in crawler by removing undefined variable `i` and printing `mid`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fa7cf31488322b87edfdbaf57aa32